### PR TITLE
Differents versions of CentOS and fix to memoryquota

### DIFF
--- a/attributes/server.rb
+++ b/attributes/server.rb
@@ -4,9 +4,10 @@ default['couchbase']['server']['version'] = '4.0.0'
 default['couchbase']['server']['username'] = 'Administrator'
 default['couchbase']['server']['password'] = 'password'
 
-# default['couchbase']['server']['memory_quota_mb'] = Couchbase::MaxMemoryQuotaCalculator.from_node(node).in_megabytes
-default['couchbase']['server']['memory_quota_mb'] = 4000
 default['couchbase']['server']['index_memory_quota_mb'] = 256
+default['couchbase']['server']['memory_quota_mb'] = Couchbase::MaxMemoryQuotaCalculator.from_node(node).in_megabytes(node)
+#default['couchbase']['server']['memory_quota_mb'] = 4000
+
 default['couchbase']['server']['services'] = 'data,query,index'
 default['couchbase']['server']['services_api'] = 'kv,n1ql,index'
 

--- a/libraries/max_memory_quota_calculator.rb
+++ b/libraries/max_memory_quota_calculator.rb
@@ -28,7 +28,7 @@ module Couchbase
       @total_in_bytes = total_in_bytes
     end
 
-    def in_megabytes
+    def in_megabytes(node)
       [max_megabytes_by_percent, max_megabytes_by_reserve].max - node['couchbase']['server']['index_memory_quota_mb']
     end
 

--- a/libraries/max_memory_quota_calculator.rb
+++ b/libraries/max_memory_quota_calculator.rb
@@ -29,7 +29,7 @@ module Couchbase
     end
 
     def in_megabytes
-      [max_megabytes_by_percent, max_megabytes_by_reserve].max
+      [max_megabytes_by_percent, max_megabytes_by_reserve].max - node['couchbase']['server']['index_memory_quota_mb']
     end
 
     protected

--- a/providers/install_server.rb
+++ b/providers/install_server.rb
@@ -24,7 +24,8 @@ def build_rpm_name(version, edition)
   if version < '3.0.0'
     return "couchbase-server-#{edition}_#{version}_#{arch}.rpm"
   else
-    return "couchbase-server-#{edition}-#{version}-centos6.#{arch}.rpm"
+    release = node['platform_version'].split('.').first
+    return "couchbase-server-#{edition}-#{version}-centos#{release}.#{arch}.rpm"
   end
 end
 


### PR DESCRIPTION
- Default install for CentOS use a rpm for centos6, the fix use a value from the attribute platform_version.

- The MaxMemoryQuotaCalculator don't considers the index_memory_quota.